### PR TITLE
Redo both Cryptostream internals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cryptostream"
 version = "0.1.0"
 authors = ["Mahmoud Al-Qudsi <mqudsi@neosmart.net>",
+        "Mark Swaanenburg <cygnus9@users.noreply.github.com>",
 		"NeoSmart Technologies <https://neosmart.net/>"]
 description = "Transparent encryption and decryption for Read and Write streams"
 homepage = "https://github.com/neosmart/cryptostream"
@@ -12,8 +13,12 @@ categories = ["cryptography"]
 license = "MIT"
 
 [dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
+log = "0.4"
+openssl = "0.10"
 
 [dev-dependencies]
 base64 = "0.9"
 rand = "0.5"
+
+[features]
+openssl-vendored = ["openssl/vendored"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate log;
 extern crate openssl;
 
 pub mod bufread;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,7 +21,7 @@ fn basic_read_encrypt() {
     let mut total_bytes_read = 0;
     loop {
         let bytes_read = encryptor
-            .read(&mut encrypted)
+            .read(&mut encrypted[total_bytes_read..])
             .expect("Encryptor read failure!");
         if bytes_read == 0 {
             break;
@@ -34,6 +34,32 @@ fn basic_read_encrypt() {
         );
         total_bytes_read += bytes_read;
     }
+
+    let mut crypter = Crypter::new(cipher, Mode::Decrypt, &key, Some(&iv)).unwrap();
+    let mut decrypted = [0u8; 1024];
+    let mut bytes_decrypted = crypter
+        .update(&encrypted[0..total_bytes_read], &mut decrypted)
+        .unwrap();
+    bytes_decrypted += crypter.finalize(&mut decrypted[bytes_decrypted..]).unwrap();
+
+    eprintln!("Decrypted {} bytes", bytes_decrypted);
+    let decrypted_msg = String::from_utf8(decrypted[0..bytes_decrypted].to_vec()).unwrap();
+    eprintln!("Decrypted message: {}", decrypted_msg);
+    assert_eq!(String::from_utf8(source.to_vec()).unwrap(), decrypted_msg);
+}
+
+#[test]
+fn basic_read_to_end_encrypt() {
+    let source: &[u8] = TEST;
+    let key: [u8; 128 / 8] = rand::random();
+    let iv: [u8; 128 / 8] = rand::random();
+    let cipher = Cipher::aes_128_cbc();
+
+    let mut encrypted = vec![];
+    let mut encryptor = read::Encryptor::new(source, cipher, &key, &iv).unwrap();
+    let total_bytes_read = encryptor.read_to_end(&mut encrypted).unwrap();
+    eprintln!("Read {} bytes out of encrypted stream", total_bytes_read);
+    eprintln!("Bytes: {:?}", &encrypted);
 
     let mut crypter = Crypter::new(cipher, Mode::Decrypt, &key, Some(&iv)).unwrap();
     let mut decrypted = [0u8; 1024];
@@ -84,6 +110,34 @@ fn basic_write_encrypt() {
 }
 
 #[test]
+fn basic_write_all_encrypt() {
+    let source: &[u8] = TEST;
+    let key: [u8; 128 / 8] = rand::random();
+    let iv: [u8; 128 / 8] = rand::random();
+    let cipher = Cipher::aes_128_cbc();
+
+    let mut encrypted = Vec::new();
+    {
+        let mut encryptor = write::Encryptor::new(&mut encrypted, cipher, &key, &iv).unwrap();
+        encryptor.write_all(source).unwrap();
+    }
+
+    eprintln!("Encrypted bytes: {:?}", &encrypted);
+
+    let mut crypter = Crypter::new(cipher, Mode::Decrypt, &key, Some(&iv)).unwrap();
+    let mut decrypted = [0u8; 1024];
+    let mut bytes_decrypted = crypter.
+        update(&encrypted, &mut decrypted)
+        .unwrap();
+    bytes_decrypted += crypter.finalize(&mut decrypted[bytes_decrypted..]).unwrap();
+
+    eprintln!("Decrypted {} bytes", bytes_decrypted);
+    let decrypted_msg = String::from_utf8(decrypted[0..bytes_decrypted].to_vec()).unwrap();
+    eprintln!("Decrypted message: {}", decrypted_msg);
+    assert_eq!(String::from_utf8(source.to_vec()).unwrap(), decrypted_msg);
+}
+
+#[test]
 fn basic_read_decrypt() {
     let source = TEST;
     let key: [u8; 128 / 8] = rand::random();
@@ -114,6 +168,31 @@ fn basic_read_decrypt() {
 }
 
 #[test]
+fn basic_read_to_end_decrypt() {
+    let key: [u8; 128 / 8] = rand::random();
+    let iv: [u8; 128 / 8] = rand::random();
+    let cipher = Cipher::aes_128_cbc();
+    let mut crypter = Crypter::new(cipher, Mode::Encrypt, &key, Some(&iv)).unwrap();
+
+    let mut encrypted = [0u8; 1024];
+    let mut bytes_written = crypter.update(TEST, &mut encrypted).unwrap();
+    bytes_written += crypter.finalize(&mut encrypted[bytes_written..]).unwrap();
+
+    let encrypted = &encrypted[0..bytes_written]; // reframe
+    let mut decrypted = vec![];
+    let bytes_decrypted;
+
+    {
+        let mut decryptor = read::Decryptor::new(encrypted, cipher, &key, &iv).unwrap();
+        bytes_decrypted = decryptor.read_to_end(&mut decrypted).unwrap();
+        eprintln!("Decrypted a total of {} bytes", bytes_decrypted);
+    }
+
+    let decrypted = &decrypted; // reframe
+    assert_eq!(&decrypted[..], TEST);
+}
+
+#[test]
 fn basic_write_decrypt() {
     let source = TEST;
     let key: [u8; 128 / 8] = rand::random();
@@ -137,6 +216,29 @@ fn basic_write_decrypt() {
             bytes_decrypted += decrypt_bytes;
         }
         eprintln!("Decrypted a total of {} bytes", bytes_decrypted);
+    }
+
+    assert_eq!(&decrypted, &TEST);
+}
+
+#[test]
+fn basic_write_all_decrypt() {
+    let key: [u8; 128 / 8] = rand::random();
+    let iv: [u8; 128 / 8] = rand::random();
+    let cipher = Cipher::aes_128_cbc();
+    let mut cryptor = Crypter::new(cipher, Mode::Encrypt, &key, Some(&iv)).unwrap();
+
+    let mut encrypted = [0u8; 1024];
+    let mut bytes_written = cryptor.update(TEST, &mut encrypted).unwrap();
+    bytes_written += cryptor.finalize(&mut encrypted[bytes_written..]).unwrap();
+
+    let encrypted = &encrypted[0..bytes_written]; // reframe
+    let mut decrypted = Vec::new();
+
+    {
+        let mut decryptor = write::Decryptor::new(&mut decrypted, cipher, &key, &iv).unwrap();
+        decryptor.write_all(encrypted).unwrap();
+        eprintln!("Decrypted a total of {} bytes", encrypted.len());
     }
 
     assert_eq!(&decrypted, &TEST);


### PR DESCRIPTION
This allows small reads on bufread::Cryptostream, which would not have
enough space to store at least one more block, as required by OpenSSL.
When one calls BufRead::read_to_end, it starts out with a 32 byte read,
which classifies as a small read.

It also allows big writes on write::Cryptostream, which won't work if
the internal buffer is smaller than the amount of data written plus that
one additional block size. Big writes are the default when one does a
std::io::copy with write::Encryptor or write::Decryptor as the
destination.

Also the commented eprintln! statements have been replaced with trace!
so a recompile isn't needed in order to debug issues.

Last, but not least, the hardcoded vendored feature for openssl is
replaced with an openssl-vendored feature in this crate so one isn't
forced to recompile openssl on all platforms.