### PR TITLE
Handle read from empty stream

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -139,3 +139,18 @@ fn basic_write_decrypt() {
 
     assert_eq!(&decrypted, &TEST);
 }
+
+#[test]
+fn empty_read_decrypt() {
+    let key: [u8; 128 / 8] = rand::random();
+    let iv: [u8; 128 / 8] = rand::random();
+    let cipher = Cipher::aes_128_cbc();
+
+    let encrypted: &[u8] = b"";
+
+    let mut decrypted = [0u8; 1024];
+
+    let mut decryptor = read::Decryptor::new(encrypted, cipher, &key, &iv).unwrap();
+    let decrypted_bytes = decryptor.read(&mut decrypted[0..]).unwrap();
+    assert_eq!(decrypted_bytes, 0);
+}


### PR DESCRIPTION
I'm using `cryptostream` to wrap a `std::net::TCPStream` and need to handle the case where the underlying socket is closed before any bytes were transferred.  An unencrypted `TCPStream` will return 0 bytes from `read` in this case.  Currently, the encrypted stream's `read` method is returning an error in this case because `finalize` is always being called.  This PR simply adds a check to see if any bytes were read before finalizing the crypter.